### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,14 @@
 # Datatypes (KEYWORD1)
 #######################################
  
-Blinky   KEYWORD1
+Blinky	KEYWORD1
  
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
  
-setupLed KEYWORD2
-blink    KEYWORD2
+setupLed	KEYWORD2
+blink	KEYWORD2
  
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords